### PR TITLE
Support insertion of title and customize newline insertions when adding reference links

### DIFF
--- a/org-zotxt.el
+++ b/org-zotxt.el
@@ -36,7 +36,7 @@
   :group 'org-zotxt
   :type '(choice (const :tag "citekey" :citekey)
                  (const :tag "citation" :citation)
-		 (const :tag "title" :title)))
+                 (const :tag "title" :title)))
 
 (defcustom org-zotxt-link-insert-newline t
   "Whether or not to insert a newline after a link.
@@ -133,9 +133,9 @@ of `org-zotxt-link-description-style'."
    (cl-case org-zotxt-link-description-style
      (:citekey (zotxt-get-item-deferred item org-zotxt-link-description-style))
      (:title (deferred:callback-post
-	       (deferred:new)
-	       (plist-put item
-			  :title (zotxt-key-to-title (plist-get item :key)))))
+               (deferred:new)
+               (plist-put item
+                          :title (zotxt-key-to-title (plist-get item :key)))))
      (t (zotxt-get-item-bibliography-deferred item)))))
 
 (defun org-zotxt-insert-reference-link (&optional arg)

--- a/zotxt.el
+++ b/zotxt.el
@@ -192,20 +192,20 @@ For use only in a `deferred:$' chain."
   "Return the complete alist of an item by ITEM-ID.
 ITEM-ID appears to be the `<libraryId>_<key>' in the `items' table."
   (let* ((item `(:key ,item-id))
-	 (plist-key :full)
-	 (zotxt--json-formats (list plist-key)))
+         (plist-key :full)
+         (zotxt--json-formats (list plist-key)))
     (->> (zotxt-get-item-deferred item plist-key)
-	 (funcall (lambda (item)
-		    (deferred:error item #'zotxt--deferred-handle-error)))
-	 deferred:sync!
-	 (funcall (lambda (plist)
-		    (plist-get plist plist-key))))))
+         (funcall (lambda (item)
+                    (deferred:error item #'zotxt--deferred-handle-error)))
+         deferred:sync!
+         (funcall (lambda (plist)
+                    (plist-get plist plist-key))))))
 
 (defun zotxt-key-to-title (item-id)
   "Return the title of a paper identified by ITEM-ID."
   (->> (zotxt-item-alist item-id)
        (funcall (lambda (alist)
-		  (or (assoc 'title-short alist) (assoc 'title alist))))
+                  (or (assoc 'title-short alist) (assoc 'title alist))))
        cdr))
 
 (defun zotxt-get-selected-items-deferred ()

--- a/zotxt.el
+++ b/zotxt.el
@@ -188,6 +188,26 @@ For use only in a `deferred:$' chain."
                       (deferred:callback-post d item))))))
     d))
 
+(defun zotxt-item-alist (item-id)
+  "Return the complete alist of an item by ITEM-ID.
+ITEM-ID appears to be the `<libraryId>_<key>' in the `items' table."
+  (let* ((item `(:key ,item-id))
+	 (plist-key :full)
+	 (zotxt--json-formats (list plist-key)))
+    (->> (zotxt-get-item-deferred item plist-key)
+	 (funcall (lambda (item)
+		    (deferred:error item #'zotxt--deferred-handle-error)))
+	 deferred:sync!
+	 (funcall (lambda (plist)
+		    (plist-get plist plist-key))))))
+
+(defun zotxt-key-to-title (item-id)
+  "Return the title of a paper identified by ITEM-ID."
+  (->> (zotxt-item-alist item-id)
+       (funcall (lambda (alist)
+		  (or (assoc 'title-short alist) (assoc 'title alist))))
+       cdr))
+
 (defun zotxt-get-selected-items-deferred ()
   "Return the currently selected items in Zotero.
 


### PR DESCRIPTION
Hi,

I have made the following changes to in this pull request:

* Added the customizable variable `org-zotxt-link-insert-newline` as a boolean
  which prevents `org-zotxt-insert-reference-link` from adding a newline (and
  going to the next line) when `nil`.  The default is `t` to avoid any change
  in behavior for those use to the current functionality.
  
* Added a new link description style `:title` to
  `org-zotxt-link-description-style`.
  
* Modified `org-zotxt-make-item-link` and
  `org-zotxt-get-item-link-text-deferred` to insert the title of the paper.

* Added `zotxt-item-alist` `zotxt-key-to-title` to support getting the title
  from zotxt.
