### PR TITLE
Feature org-zotxt-search-open-attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ To update the current link text at point to reflect changed metadata from Zotero
 
 To open an attachment of the link at point, use `C-c " a` (`org-zotxt-open-attachment`)
 
+To look up a reference and open its attachment, use `C-c " o` (`org-zotxt-search-open-attachment`)
+
 # Pandoc citekey integration
 
 To insert citation keys into a markdown document (for use with pandoc), first enable  `zotxt-citekey` minor mode:


### PR DESCRIPTION
Create a new function `org-zotxt-search-open-attachement` and bind it to `C-c " o`, which looks up an item and opens the attachment. It allows one to open an attachment without inserting the item.