### PR TITLE
fix: handle :title link description correctly

### DIFF
--- a/org-zotxt.el
+++ b/org-zotxt.el
@@ -130,13 +130,14 @@ See `org-zotxt-insert-reference-link'."
 May be either an citekey or bibliography, depending on the value
 of `org-zotxt-link-description-style'."
   (let ((item (copy-tree item)))
-   (cl-case org-zotxt-link-description-style
-     (:citekey (zotxt-get-item-deferred item org-zotxt-link-description-style))
-     (:title (deferred:callback-post
-               (deferred:new)
-               (plist-put item
-                          :title (zotxt-key-to-title (plist-get item :key)))))
-     (t (zotxt-get-item-formatted-deferred item)))))
+    (cl-case org-zotxt-link-description-style
+      (:citekey (zotxt-get-item-deferred item org-zotxt-link-description-style))
+      (:title (let ((d (deferred:new)))
+                (deferred:callback-post
+                 d
+                 (plist-put item :title (zotxt-key-to-title (plist-get item :key))))
+                d))
+      (t (zotxt-get-item-formatted-deferred item)))))
 
 (defun org-zotxt-insert-reference-link (&optional arg)
   "Insert a zotero link in the `org-mode' document.


### PR DESCRIPTION
Fixes #75 

The issue is that `org-zotxt-get-item-link-text-deferred` is expected to return a *deferred* in every branch.  But for the `:title` branch it currently returns the value of `deferred:callback-post`, i.e. `nil`, not the deferred object.  
Later in the chain the value is treated as a deferred which gives the message.

This fix ensures that a `deferred` object is returned.
